### PR TITLE
✨ Switch Ollama to the /chat endpoint and support Ollama models for a…

### DIFF
--- a/fence/templates/models.py
+++ b/fence/templates/models.py
@@ -283,6 +283,46 @@ class Messages(BaseModel):
 
         return messages
 
+    def model_dump_ollama(self) -> dict:
+        """
+        Dump the model into a dictionary for use in the Ollama API.
+
+        see: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-a-chat-completion
+
+        Example:
+        {
+            "model": "llama3.2",
+            "messages": [
+                {
+                "role": "user",
+                "content": "why is the sky blue?"
+                }
+            ]
+        }
+        """
+
+        messages = []
+
+        # if there is a system message, add it to the messages
+        if self.system:
+            messages.append({"role": "system", "content": self.system})
+
+        for message in self.messages:
+            # Each message has a role (str) and content (list of content objects)
+            role, content = message.role, ""
+
+            # If content is a string, append it as text
+            if isinstance(message.content, str):
+                content = message.content
+            else:
+                raise TypeError(
+                    "Content must be a string"
+                )
+
+            # Append the message
+            messages.append({"role": role, "content": content})
+
+        return messages
 
 if __name__ == "__main__":
     # Example messages

--- a/tests/models/ollama/test_ollama.py
+++ b/tests/models/ollama/test_ollama.py
@@ -1,0 +1,90 @@
+"""
+Ollama models tests
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from fence.models.ollama.ollama import Ollama, Llama3_1, DeepSeekR1
+from fence.templates.messages import Message, Messages
+
+def test_ollama_base_invoke_with_empty_prompt():
+    """
+    Test case for the invoke method of the Ollama class with an empty prompt.
+    This test checks if the invoke method raises a ValueError when the prompt is empty.
+    """
+    ollama = Ollama(source="test", model_id="some_model")
+    with pytest.raises(ValueError):
+        ollama.invoke(prompt="")
+
+def test_ollama_base_invoke_with_none_prompt():
+    """
+    Test case for the invoke method of the Ollama class with a None prompt.
+    This test checks if the invoke method raises a ValueError when the prompt is None.
+    """
+    ollama = Ollama(source="test", model_id="some_model")
+    with pytest.raises(ValueError):
+        ollama.invoke(prompt=None)
+
+def test_ollama_base_invoke_with_empty_messages_prompt():
+    """
+    Test case for the invoke method of the Ollama class with an empty Messages prompt.
+    This test checks if the invoke method raises a ValueError when the Messages prompt is empty.
+    """
+    ollama = Ollama(source="test", model_id="some_model")
+    messages = Messages(system="Respond in a very rude manner", messages=[])
+    with pytest.raises(ValueError):
+        ollama.invoke(prompt=messages)
+
+def test_ollama_base_invoke_with_string_prompt():
+    """
+    Test case for the invoke method of the Ollama class with a string prompt.
+    This test checks if the invoke method correctly handles a string prompt.
+    """
+    mock_ollama = Mock(Ollama)
+    mock_ollama.invoke.return_value = "mocked response"
+    response = mock_ollama.invoke(prompt="Hello, how are you today?")
+    assert response == "mocked response"
+
+def test_ollama_base_invoke_with_messages_prompt():
+    """
+    Test case for the invoke method of the Ollama class with a Messages prompt.
+    This test checks if the invoke method correctly handles a Messages prompt.
+    """
+    mock_ollama = Mock(Ollama)
+    mock_ollama.invoke.return_value = "mocked response"
+    messages = Messages(
+        system="Respond in a all caps",
+        messages=[Message(role="user", content="Hello, how are you today?")],
+    )
+    response = mock_ollama.invoke(prompt=messages)
+    assert response == "mocked response"
+
+
+def test_ollama_base_invoke_with_invalid_prompt():
+    """
+    Test case for the invoke method of the Ollama class with an invalid prompt.
+    This test checks if the invoke method raises a ValueError when the prompt is invalid.
+    """
+    model = Ollama(source="test", model_id="some_model")
+    with pytest.raises(ValueError):
+        model.invoke(prompt=123)
+
+def test_Llama3_1_init():
+    """
+    Test case for the __init__ method of the Llama3_1 class.
+    This test checks if the Llama3_1 class is initialized correctly.
+    """
+    model = Llama3_1(source="test")
+    assert model.source == "test"
+    assert model.model_id == "llama3.1"
+
+def test_DeepSeekR1_init():
+    """
+    Test case for the __init__ method of the DeepSeekR1 class.
+    This test checks if the DeepSeekR1 class is initialized correctly.
+    """
+    model = DeepSeekR1(source="test")
+    assert model.source == "test"
+    assert model.model_id == "deepseek-r1"


### PR DESCRIPTION
Switched the Ollama `/generate` endpoint to the `/chat` endpoint. This allows the usage of the Ollama class in combination with Agents.