### PR TITLE
security: Fix HTTP request safety issues across all providers

### DIFF
--- a/fence/embeddings/google/gemini.py
+++ b/fence/embeddings/google/gemini.py
@@ -120,7 +120,8 @@ class GeminiEmbeddingsBase(Embeddings):
             response = requests.post(
                 self._get_embedding_endpoint(),
                 headers=headers,
-                json=data
+                json=data,
+                timeout=60,
             )
 
             # Check status code

--- a/fence/embeddings/mistral/mistral.py
+++ b/fence/embeddings/mistral/mistral.py
@@ -54,7 +54,7 @@ class MistralEmbeddingsBase(Embeddings):
         }
         
         try:
-            response = requests.post(self.embedding_endpoint, headers=headers, json=data)
+            response = requests.post(self.embedding_endpoint, headers=headers, json=data, timeout=60)
         
             # Check status code
             if response.status_code != 200:

--- a/fence/embeddings/ollama/ollama.py
+++ b/fence/embeddings/ollama/ollama.py
@@ -44,7 +44,7 @@ class OllamaEmbeddingBase(Embeddings):
 
         # Check if the endpoint is valid
         try:
-            requests.get(self.embedding_endpoint)
+            requests.get(self.embedding_endpoint, timeout=10)
         except requests.exceptions.ConnectionError:
             raise ValueError(
                 f"No Ollama service found at {self.endpoint}. Try installing it using `brew install ollama`."
@@ -68,19 +68,19 @@ class OllamaEmbeddingBase(Embeddings):
 
         try:
             response = requests.post(
-                url=self.embedding_endpoint, json=payload
+                url=self.embedding_endpoint, json=payload, timeout=60,
             )
 
         except Exception as e:
             raise ValueError(f"Error raised by Ollama service: {e}")
-        
-        if response.status_code != 200 and response.text.__contains__("not found"):
+
+        if response.status_code != 200 and "not found" in response.text:
             logger.warning(f"Model {self.model_id} not found in Ollama service - trying to pull it")
 
             self._pull_model(model_id=self.model_id)
 
             try:
-                response = requests.post(url=self.embedding_endpoint, json=payload)
+                response = requests.post(url=self.embedding_endpoint, json=payload, timeout=60)
             except Exception as e:
                 raise ValueError(f"Error raised by Ollama service: {e}")
             
@@ -97,7 +97,8 @@ class OllamaEmbeddingBase(Embeddings):
         # Send request
         try:
             response = requests.post(
-                url=self.pull_endpoint, json={"name": model_id}, stream=False
+                url=self.pull_endpoint, json={"name": model_id}, stream=False,
+                timeout=300,
             )
 
         except Exception as e:
@@ -113,7 +114,7 @@ class OllamaEmbeddingBase(Embeddings):
 
         # Send request
         try:
-            response = requests.get(url=self.tag_endpoint)
+            response = requests.get(url=self.tag_endpoint, timeout=10)
 
         except Exception as e:
             raise ValueError(f"Error raised by Ollama service: {e}")

--- a/fence/embeddings/openai/openai.py
+++ b/fence/embeddings/openai/openai.py
@@ -56,7 +56,7 @@ class OpenAIEmbeddingsBase(Embeddings):
         }
         
         try:
-            response = requests.post(self.embedding_endpoint, headers=headers, json=data)
+            response = requests.post(self.embedding_endpoint, headers=headers, json=data, timeout=60)
         
             # Check status code
             if response.status_code != 200:

--- a/fence/models/anthropic/claude.py
+++ b/fence/models/anthropic/claude.py
@@ -160,7 +160,8 @@ class ClaudeBase(LLM, MessagesMixin):
 
             # Send request to Anthropic
             response = requests.post(
-                url=self.url, headers=headers, data=json.dumps(request_body)
+                url=self.url, headers=headers, data=json.dumps(request_body),
+                timeout=60,
             )
 
             # Check status code

--- a/fence/models/gemini/gemini.py
+++ b/fence/models/gemini/gemini.py
@@ -138,17 +138,14 @@ class GeminiBase(LLM):
             # send request to Google
             headers = {
                 "Content-Type": "application/json",
-            }
-
-            params = {
-                "key": self.api_key,
+                "x-goog-api-key": self.api_key,
             }
 
             response = requests.post(
                 url=self.endpoint.format(model_id=self.model_id),
                 headers=headers,
-                params=params,
                 data=json.dumps(request_body),
+                timeout=60,
             )
 
             if response.status_code != 200:

--- a/fence/models/mistral/mistral.py
+++ b/fence/models/mistral/mistral.py
@@ -157,7 +157,8 @@ class MistralBase(LLM, MessagesMixin):
 
             # Send request to Mistral
             response = requests.post(
-                url=self.chat_endpoint, headers=headers, data=json.dumps(request_body)
+                url=self.chat_endpoint, headers=headers, data=json.dumps(request_body),
+                timeout=60,
             )
 
             # Check status code

--- a/fence/models/ollama/ollama.py
+++ b/fence/models/ollama/ollama.py
@@ -48,7 +48,7 @@ class OllamaBase(LLM, MessagesMixin):
 
         # Check if the endpoint is valid
         try:
-            requests.get(self.tag_endpoint)
+            requests.get(self.tag_endpoint, timeout=10)
         except requests.exceptions.ConnectionError:
             raise ValueError(
                 f"No Ollama service found at {self.endpoint}. Try installing it using `brew install ollama`."
@@ -150,13 +150,13 @@ class OllamaBase(LLM, MessagesMixin):
 
         # Send request
         try:
-            response = requests.post(url=self.chat_endpoint, json=payload)
+            response = requests.post(url=self.chat_endpoint, json=payload, timeout=120)
 
         except Exception as e:
             raise ValueError(f"Error raised by Ollama service: {e}")
 
         # Check if the response is valid
-        if response.status_code != 200 and response.text.__contains__("not found"):
+        if response.status_code != 200 and "not found" in response.text:
             logger.warning(
                 f"Model {self.model_id} not found in Ollama service - trying to pull it"
             )
@@ -164,7 +164,7 @@ class OllamaBase(LLM, MessagesMixin):
 
             # Retry the request
             try:
-                response = requests.post(url=self.chat_endpoint, json=payload)
+                response = requests.post(url=self.chat_endpoint, json=payload, timeout=120)
             except Exception as e:
                 raise ValueError(f"Error raised by Ollama service: {e}")
 
@@ -180,7 +180,8 @@ class OllamaBase(LLM, MessagesMixin):
         # Send request
         try:
             response = requests.post(
-                url=self.pull_endpoint, json={"name": model_id}, stream=False
+                url=self.pull_endpoint, json={"name": model_id}, stream=False,
+                timeout=300,
             )
 
         except Exception as e:
@@ -196,7 +197,7 @@ class OllamaBase(LLM, MessagesMixin):
 
         # Send request
         try:
-            response = requests.get(url=self.tag_endpoint)
+            response = requests.get(url=self.tag_endpoint, timeout=10)
 
         except Exception as e:
             raise ValueError(f"Error raised by Ollama service: {e}")

--- a/fence/models/openai/gpt.py
+++ b/fence/models/openai/gpt.py
@@ -155,7 +155,8 @@ class GPTBase(LLM, MessagesMixin):
 
             # Send request to OpenAI
             response = requests.post(
-                url=self.url, headers=headers, data=json.dumps(request_body)
+                url=self.url, headers=headers, data=json.dumps(request_body),
+                timeout=60,
             )
 
             # Check status code

--- a/tests/models/gemini/test_gemini_base.py
+++ b/tests/models/gemini/test_gemini_base.py
@@ -3,7 +3,7 @@ Tests for the GeminiBase class and related functionality.
 """
 
 import os
-from unittest.mock import Mock
+from unittest.mock import Mock, patch, MagicMock
 
 import pytest
 
@@ -90,3 +90,52 @@ def test_gemini_base_invoke_with_invalid_prompt():
     gemini = MockGeminiModel()
     with pytest.raises(ValueError):
         gemini.invoke(prompt=123)
+
+
+@patch("fence.models.gemini.gemini.requests.post")
+def test_gemini_api_key_sent_in_header_not_params(mock_post):
+    """
+    Test that the Gemini API key is sent via the x-goog-api-key header,
+    not as a URL query parameter, to prevent key leakage in logs.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "candidates": [{"content": {"parts": [{"text": "mocked response"}]}}],
+        "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 20},
+    }
+    mock_post.return_value = mock_response
+
+    gemini = Gemini(model_id="gemini-2.0-flash", source="test", api_key="test-secret-key")
+    gemini.invoke(prompt="Hello")
+
+    mock_post.assert_called_once()
+    call_kwargs = mock_post.call_args
+
+    # API key must be in headers
+    assert call_kwargs.kwargs["headers"]["x-goog-api-key"] == "test-secret-key"
+
+    # API key must NOT be in URL params
+    assert "params" not in call_kwargs.kwargs or call_kwargs.kwargs.get("params") is None
+
+
+@patch("fence.models.gemini.gemini.requests.post")
+def test_gemini_request_has_timeout(mock_post):
+    """
+    Test that Gemini API requests include an explicit timeout
+    to prevent indefinite hangs.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "candidates": [{"content": {"parts": [{"text": "mocked response"}]}}],
+        "usageMetadata": {"promptTokenCount": 10, "candidatesTokenCount": 20},
+    }
+    mock_post.return_value = mock_response
+
+    gemini = Gemini(model_id="gemini-2.0-flash", source="test", api_key="test-key")
+    gemini.invoke(prompt="Hello")
+
+    call_kwargs = mock_post.call_args
+    assert "timeout" in call_kwargs.kwargs
+    assert call_kwargs.kwargs["timeout"] > 0


### PR DESCRIPTION
## Summary

- **Gemini API key moved from URL query params to `x-goog-api-key` header** — prevents key leakage in server/proxy logs and HTTP referer headers
- **Added explicit timeouts to all `requests.post()` and `requests.get()` calls** across all model and embedding providers — prevents indefinite hangs and resource exhaustion (60s for API calls, 120s for Ollama chat, 300s for model pulls, 10s for health checks)
- **Replaced `__contains__` anti-pattern with idiomatic `in` operator** in Ollama model and embedding modules

## Files changed (9)

| File | Fix |
|------|-----|
| `fence/models/gemini/gemini.py` | API key to header + timeout |
| `fence/models/openai/gpt.py` | timeout |
| `fence/models/anthropic/claude.py` | timeout |
| `fence/models/mistral/mistral.py` | timeout |
| `fence/models/ollama/ollama.py` | timeout + `__contains__` fix |
| `fence/embeddings/google/gemini.py` | timeout |
| `fence/embeddings/openai/openai.py` | timeout |
| `fence/embeddings/mistral/mistral.py` | timeout |
| `fence/embeddings/ollama/ollama.py` | timeout + `__contains__` fix |

## Test plan

- [x] All 9 modified files pass Python syntax validation
- [x] Verify Gemini API calls still authenticate correctly with header-based key
- [ ] Verify no regressions in existing provider integrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)